### PR TITLE
chore: Add subproject owners to a central place

### DIFF
--- a/SUBPROJECT-OWNERS.md
+++ b/SUBPROJECT-OWNERS.md
@@ -1,0 +1,8 @@
+- Avi Deitcher (@deitch)
+- Feynman Zhou (@FeynmanZhou)
+- Josh Dolitsky (@jdolitsky)
+- Sajay Antony (@sajayantony)
+- Shiwei Zhang (@shizhMSFT)
+- Steve Lasker (@stevelasker)
+- Sylvia Lei (@Wwwsylvia)
+- Vanessasaurus (@vsoch)


### PR DESCRIPTION
Fix https://github.com/oras-project/community/issues/23 also one item of https://github.com/oras-project/community/issues/28].

If this PR is approved and merged, we will sync it to the [CNCF maintainer list](https://github.com/cncf/foundation/blob/main/project-maintainers.csv). 
