### PR TITLE
chore: update owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Derived from OWNERS.md
-* @sabre1041 @deitch @jdolitsky @sajayantony @shizhMSFT @stevelasker @TerryHowe
+* @sabre1041 @sajayantony @shizhMSFT @stevelasker @TerryHowe

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -2,9 +2,11 @@
 
 Owners:
   - Andrew Block (@sabre1041)
-  - Avi Deitcher (@deitch)
-  - Josh Dolitsky (@jdolitsky)
   - Sajay Antony (@sajayantony)
   - Shiwei Zhang (@shizhMSFT)
   - Steve Lasker (@stevelasker)
   - Terry Howe (@TerryHowe)
+
+Emeritus:
+  - Avi Deitcher (@deitch)
+  - Josh Dolitsky (@jdolitsky)


### PR DESCRIPTION
This PR aggregates the following changes:
- Move Avi Deitcher (@deitch) to emeritus (as requested by https://github.com/oras-project/community/issues/37)
- Move Josh Dolitsky (@jdolitsky) to emeritus (as requested by https://github.com/oras-project/community/issues/32)