### PR TITLE
chore: move Steve Lasker to emeritus

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Derived from OWNERS.md
-* @sabre1041 @sajayantony @shizhMSFT @stevelasker @TerryHowe
+* @sabre1041 @sajayantony @shizhMSFT @TerryHowe

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -4,9 +4,9 @@ Owners:
   - Andrew Block (@sabre1041)
   - Sajay Antony (@sajayantony)
   - Shiwei Zhang (@shizhMSFT)
-  - Steve Lasker (@stevelasker)
   - Terry Howe (@TerryHowe)
 
 Emeritus:
   - Avi Deitcher (@deitch)
   - Josh Dolitsky (@jdolitsky)
+  - Steve Lasker (@stevelasker)


### PR DESCRIPTION
Steve Lasker has not been active for over six months. While Steve's contributions greatly appreciated, priorities change