### PR TITLE
fix: limit binding votes to org maintainers

### DIFF
--- a/.gitvote.yml
+++ b/.gitvote.yml
@@ -83,8 +83,11 @@ profiles:
     #     - cynthia-sg
     #     - tegioz
     #
+    # Only the org maintainers listed in OWNERS.md have a binding vote. They
+    # are kept in sync via the oras-org-maintainers team.
     allowed_voters:
-      teams: []
+      teams:
+        - oras-org-maintainers
       users: []
 
   # Additional configuration profiles


### PR DESCRIPTION
## What this does

The `default` gitvote profile declared `allowed_voters` with empty `teams`
and `users` lists. Per the [gitvote docs](https://github.com/cncf/gitvote),
that means *all repository collaborators* hold a binding vote — including
outside collaborators and anyone with access through default org
permissions.

This sets the default profile's allowed voters to the `oras-org-maintainers`
team, so only org maintainers have a binding vote.

## Why the team rather than an explicit user list

`OWNERS.md` is the source of truth for org owners. The `oras-org-maintainers`
team membership currently matches it exactly (@sabre1041, @sajayantony,
@shizhMSFT, @TerryHowe), and the existing `maintainers` profile already
references that team. Using the team keeps the config in sync automatically
instead of adding a third place to update when ownership changes
(`OWNERS.md`, `CODEOWNERS`, and this file).

The `maintainers` profile is left as-is — it still provides the higher 75%
pass threshold for governance-level decisions.

Closes: #82